### PR TITLE
3.2.1 release (#5525)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+.. _v3-2-1:
+
+3.2.1 - 2020-10-27
+~~~~~~~~~~~~~~~~~~
+
+* Disable blinding on RSA public keys to address an error with some versions
+  of OpenSSL.
+
 .. _v3-2:
 
 3.2 - 2020-10-25

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -22,10 +22,10 @@ __summary__ = (
 )
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.2"
+__version__ = "3.2.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"
 
 __license__ = "BSD or Apache License, Version 2.0"
-__copyright__ = "Copyright 2013-2019 {}".format(__author__)
+__copyright__ = "Copyright 2013-2020 {}".format(__author__)

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -410,11 +410,6 @@ class _RSAPrivateKey(object):
 @utils.register_interface(RSAPublicKeyWithSerialization)
 class _RSAPublicKey(object):
     def __init__(self, backend, rsa_cdata, evp_pkey):
-        # Blinding is on by default in many versions of OpenSSL, but let's
-        # just be conservative here.
-        res = backend._lib.RSA_blinding_on(rsa_cdata, backend._ffi.NULL)
-        backend.openssl_assert(res == 1)
-
         self._backend = backend
         self._rsa_cdata = rsa_cdata
         self._evp_pkey = evp_pkey

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1894,6 +1894,9 @@ class TestRSANumbers(object):
         public_key = RSA_KEY_1024.public_numbers.public_key(backend)
         assert public_key
 
+        public_key = rsa.RSAPublicNumbers(n=10, e=3).public_key(backend)
+        assert public_key
+
     def test_public_numbers_invalid_types(self):
         with pytest.raises(TypeError):
             rsa.RSAPublicNumbers(e=None, n=15)

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -20,10 +20,10 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.2"
+__version__ = "3.2.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"
 
 __license__ = "BSD or Apache License, Version 2.0"
-__copyright__ = "Copyright 2013-2019 %s" % __author__
+__copyright__ = "Copyright 2013-2020 %s" % __author__


### PR DESCRIPTION
* Disable blinding for RSA pub keys (#5524)

* Bump to 3.2.1